### PR TITLE
chore(deps): update npm packages, workflows and pre-commit hooks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         language: ["actions", "javascript"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/codeql-analysis@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,15 +13,19 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      packages: read
-      security-events: write
+      actions: read # required by CodeQL to read workflow run metadata
+      contents: read # required to check out the repository
+      packages: read # required to read packages during analysis
+      security-events: write # required to upload CodeQL results to the Security tab
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -27,4 +27,4 @@ jobs:
     steps:
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   Linter:
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      statuses: write
-      contents: read
-      packages: read
+      statuses: write # required to publish lint status checks on commits
+      contents: read # required to check out the repository
+      packages: read # required to read packages during linting
 
     steps:
       - name: Run PR Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # required to query CI workflow run status
+  contents: read # required to check out the repository
 
 jobs:
   validate:
@@ -36,12 +36,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🔢 Extract Version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_VERSION"
             VERSION="${VERSION#v}"
             echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
           else
@@ -51,8 +55,9 @@ jobs:
           echo "Releasing version: ${VERSION}"
 
       - name: ✅ Validate Version Format
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "❌ Invalid version format: $VERSION"
             echo "Expected format: v1.0.0 or v1.0.0-beta.1"
@@ -105,27 +110,17 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 24
+        # zizmor: ignore[cache-poisoning] no cache input is set, so nothing is restored
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
-      - name: Cache Node.js dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.npm
-            ~/.yarn
-            ~/.cache/yarn
-            ~/.pnpm-store
-            ~/.cache/pnpm
-            node_modules/.cache
-          key: ${{ runner.os }}-node-24-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-24-
-            ${{ runner.os }}-node-
-
+      # No dependency cache in the publish path: a cache poisoned from a PR-triggered
+      # run must never reach the release/publish jobs.
       - name: Install Dependencies
         run: npm ci || { echo "❌ npm install failed"; npm install; }
 
@@ -138,54 +133,36 @@ jobs:
     timeout-minutes: 15
     needs: [validate, check-ci, security]
     if: always() && needs.validate.result == 'success' && needs.check-ci.result == 'success' && needs.security.result == 'success'
+    # Scope the npm publish secret to a protected deployment environment.
+    environment: release
     permissions:
-      contents: write
-      packages: write
-      issues: write
-      pull-requests: write
+      contents: write # required to push the release tag and create the GitHub release
+      packages: write # required to publish the package
+      issues: write # required by release tooling to comment on issues
+      pull-requests: write # required by release tooling to comment on PRs
 
     steps:
       - name: ⤵️ Checkout Repository
+        # persist-credentials is intentionally left enabled: the "Create Tag" step
+        # below pushes a tag with the checkout-provided GITHUB_TOKEN.
+        # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js 24
+        # zizmor: ignore[cache-poisoning] no cache input is set, so nothing is restored
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 
-      - name: Cache Node.js dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.npm
-            ~/.yarn
-            ~/.cache/yarn
-            ~/.pnpm-store
-            ~/.cache/pnpm
-            node_modules/.cache
-          key: ${{ runner.os }}-node-24-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-24-
-            ${{ runner.os }}-node-
-
+      # No dependency or grammar cache in the publish path: a cache poisoned from a
+      # PR-triggered run must never reach the published artifact.
       - name: Install Dependencies
         run: npm ci || { echo "❌ npm install failed"; npm install; }
 
-      - name: Cache Generated Grammar
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-grammar
-        with:
-          path: |
-            src/parser.c
-            src/tree_sitter/
-            binding.gyp
-          key: ${{ runner.os }}-grammar-${{ hashFiles('grammar.js', 'package.json', 'src/scanner.c') }}
-
       - name: Generate Grammar
-        if: steps.cache-grammar.outputs.cache-hit != 'true'
         run: npm run generate
 
       - name: 🏗️ Build Parser
@@ -193,8 +170,10 @@ jobs:
 
       - name: 🔎 Verify package.json version matches input
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          INPUT="${{ github.event.inputs.version }}"
+          INPUT="$INPUT_VERSION"
           EXPECTED="v${INPUT#v}"
           PKG="v$(node -p "require('./package.json').version")"
           if [ "$PKG" != "$EXPECTED" ]; then
@@ -205,15 +184,18 @@ jobs:
 
       - name: 🏷️ Create Tag
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="v${{ github.event.inputs.version }}"
+          VERSION="v$INPUT_VERSION"
           git tag "${VERSION#v}"
           git push origin "${VERSION#v}"
 
       - name: 📝 Generate Release Notes
         id: release_notes
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION="${{ needs.validate.outputs.version }}"
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
 
           {
@@ -248,17 +230,20 @@ jobs:
           } >> release_notes.md
 
       - name: 🚀 Create GitHub Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          tag_name: ${{ needs.validate.outputs.version }}
-          name: Release ${{ needs.validate.outputs.version }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: ${{ contains(needs.validate.outputs.version, '-') }}
-          generate_release_notes: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          args=(--title "Release ${VERSION}" --notes-file release_notes.md)
+          if [[ "$VERSION" == *"-"* ]]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$VERSION" "${args[@]}"
 
       - name: 📦 Publish to npm
-        run: |
+        # Token-based publish: trusted publishing requires the package to be
+        # configured for an OIDC trusted publisher on npmjs.com (external setup).
+        run: | # zizmor: ignore[use-trusted-publishing]
           if [[ "$VERSION" == *"-"* ]]; then
             PUBLISH_TAG="next"
           else
@@ -271,7 +256,11 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
 
       - name: 📊 Release Summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          echo "🎉 Successfully released ${{ needs.validate.outputs.version }}"
+          echo "🎉 Successfully released ${VERSION}"
           echo "📦 Published to npm: https://www.npmjs.com/package/@ivuorinen/tree-sitter-shellspec"
-          echo "🏷️ GitHub Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.version }}"
+          echo "🏷️ GitHub Release: ${SERVER_URL}/${REPOSITORY}/releases/tag/${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,11 +185,12 @@ jobs:
       - name: 🏷️ Create Tag
         if: github.event_name == 'workflow_dispatch'
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION="v$INPUT_VERSION"
-          git tag "${VERSION#v}"
-          git push origin "${VERSION#v}"
+          # Use the validated, v-prefixed version so the pushed tag matches the
+          # tag the GitHub release is created for (gh release create "$VERSION").
+          git tag "$VERSION"
+          git push origin "$VERSION"
 
       - name: 📝 Generate Release Notes
         id: release_notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: 📋 Check CI Workflow Status
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const wfList = await github.rest.actions.listRepoWorkflows({
@@ -248,7 +248,7 @@ jobs:
           } >> release_notes.md
 
       - name: 🚀 Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ needs.validate.outputs.version }}
           name: Release ${{ needs.validate.outputs.version }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/stale@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+      - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  packages: read
-  statuses: read
+  contents: read # required to read repository metadata
+  packages: read # required to read packages
+  statuses: read # required to read commit statuses
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   stale:
@@ -20,7 +24,7 @@ jobs:
 
     permissions:
       contents: write # only for delete-branch option
-      issues: write
-      pull-requests: write
+      issues: write # required to comment on and close stale issues
+      pull-requests: write # required to comment on and close stale PRs
     steps:
       - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: ⤵️ Sync Latest Labels Definitions
-        uses: ivuorinen/actions/sync-labels@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/sync-labels@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,7 +19,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   labels:
@@ -28,13 +28,14 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: read
-      issues: write
+      contents: read # required to read the labels definition
+      issues: write # required to create and update repository labels
 
     steps:
       - name: ⤵️ Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: ⤵️ Sync Latest Labels Definitions
         uses: ivuorinen/actions/sync-labels@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  actions: write
+permissions: {}
 
 jobs:
   test:
@@ -22,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: read
-      contents: read
-      issues: write
-      pull-requests: write
+      actions: read # required to read workflow run metadata for the matrix
+      contents: read # required to check out the repository
+      issues: write # required for test tooling to post status to issues
+      pull-requests: write # required for test tooling to post status to PRs
 
     strategy:
       matrix:
@@ -35,6 +33,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -156,13 +156,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
-      issues: write
-      pull-requests: write
+      contents: read # required to check out the repository
+      issues: write # required for the linter to post status to issues
+      pull-requests: write # required for the linter to post status to PRs
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -197,14 +199,16 @@ jobs:
     timeout-minutes: 15
     needs: test
     permissions:
-      actions: read
-      contents: read
-      issues: write
-      pull-requests: write
+      actions: read # required to read workflow run metadata
+      contents: read # required to check out the repository
+      issues: write # required for coverage tooling to post status to issues
+      pull-requests: write # required for coverage tooling to post status to PRs
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: read # required to read workflow run metadata for the matrix
       contents: read # required to check out the repository
-      issues: write # required for test tooling to post status to issues
-      pull-requests: write # required for test tooling to post status to PRs
 
     strategy:
       matrix:
@@ -199,10 +196,7 @@ jobs:
     timeout-minutes: 15
     needs: test
     permissions:
-      actions: read # required to read workflow run metadata
       contents: read # required to check out the repository
-      issues: write # required for coverage tooling to post status to issues
-      pull-requests: write # required for coverage tooling to post status to PRs
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,7 @@ jobs:
         shell: bash
 
       - name: 🧹 Run Linter
-        uses: ivuorinen/actions/pr-lint@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
 
   coverage:
     name: 📊 Test Coverage

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -26,12 +26,14 @@ DISABLE_LINTERS:
   - CPP_CPPCHECK # Generated src/ files (false positives)
   - CPP_CPPLINT # Generated src/ files (false positives)
   - BASH_SHFMT # Doesn't understand ShellSpec DSL syntax
-  - BASH_BASH_EXEC # Test spec files are sourced by ShellSpec, not executed directly
   - JSON_PRETTIER # Disabled for causing problems
   - SPELL_LYCHEE # Disabled due to too many false positives
   - SPELL_CSPELL # Disabled due to too many false positives
   - REPOSITORY_TRUFFLEHOG # Disabled due to being far too slow
   - JAVASCRIPT_PRETTIER # We are not using Prettier for JS
+
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
 
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yml
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,6 @@ repos:
       - id: actionlint
         args: ["-shellcheck="]
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 43.150.0
-    hooks:
-      - id: renovate-config-validator
-
   - repo: https://github.com/bridgecrewio/checkov.git
     rev: "3.3.1"
     hooks:

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,0 +1,99 @@
+# Nitpicker Findings
+
+Generated: 2026-06-24
+Last validated: 2026-06-24
+
+Scope: changed-files mode — branch `feat/upgrades` vs `origin/main` (PR #121).
+Reviewed: `.github/workflows/*.yml`, `.mega-linter.yml`, `.pre-commit-config.yaml`, `package.json`.
+
+## Summary
+
+- Total: 7 | Open: 3 | Fixed: 3 | Invalid: 1
+
+## Open Findings
+
+### Medium
+
+#### [NIT-03] Same pr-lint action granted contradictory permissions across workflows
+
+Category: security
+Area: .github/workflows/test.yml (job `lint`) vs .github/workflows/pr-lint.yml (job `Linter`)
+Problem: The identical pinned action `ivuorinen/actions/pr-lint@8395dad…` is invoked with two
+different permission sets. In `pr-lint.yml` it gets `statuses: write`, `contents: read`,
+`packages: read`. In `test.yml` it gets `contents: read`, `issues: write`, `pull-requests: write`
+— no `statuses: write`. The justification comments on both cannot both be accurate.
+Evidence: pr-lint.yml:22-25 vs test.yml:158-161 (post-edit numbering).
+Impact: At least one invocation is mis-scoped: either the `test.yml` `lint` job is missing
+`statuses: write` it needs (lint status check fails to publish), or it holds `issues`/`pull-requests`
+write it never uses (over-privilege). The comments document a requirement that is not verified.
+Fix: Determine the action's actual required scopes (from its `action.yml`/docs) and apply the same
+permission block in both call sites. Not auto-applied: the action is an external black box and
+guessing risks breaking the status check.
+
+### Low
+
+#### [NIT-05] Redundant `token:` input on sync-labels checkout
+
+Category: maintainability
+Area: .github/workflows/sync-labels.yml:38
+Problem: `token: ${{ secrets.GITHUB_TOKEN }}` restates the checkout action's default token, and is
+paired with `persist-credentials: false`, so it has no effect — the credential is not persisted and
+the value equals the default.
+Evidence: sync-labels.yml:37-39.
+Impact: Dead configuration; implies a non-default token is in use when it is not.
+Fix: Remove the `token:` line, keeping `persist-credentials: false`.
+
+#### [NIT-06] renovate-config-validator removed while renovate config still present
+
+Category: maintainability
+Area: .pre-commit-config.yaml (removed hook) / .github/renovate.json (still present)
+Problem: This branch deletes the `renovatebot/pre-commit-hooks` `renovate-config-validator` hook,
+but `.github/renovate.json` still exists. Local validation of the Renovate config is now gone.
+Evidence: diff removes the hook block; `.github/renovate.json` present (extends
+`github>ivuorinen/renovate-config`).
+Impact: A malformed `.github/renovate.json` will no longer be caught pre-commit; only Renovate's own
+server-side handling remains. Low impact because the file is a trivial `extends` shim.
+Fix: Either restore the hook, or accept the reduced coverage intentionally and note it. Reported, not
+auto-applied — removal may be deliberate (network/flaky hook).
+
+## Fixed
+
+### Pass 1 — 2026-06-24
+
+#### [NIT-01] Release workflow_dispatch pushes a tag that mismatches the release tag
+
+Fixed: 2026-06-24
+Notes: On the `workflow_dispatch` path, "Create Tag" computed the tag from the raw input
+(`git tag "${VERSION#v}"`), pushing an unprefixed tag (e.g. `1.0.0`) while "Create GitHub Release"
+ran `gh release create "$VERSION"` with the validated, v-prefixed version (`v1.0.0`). Because the
+input description tells users to enter `1.0.0`, the common path produced two divergent tags, and
+`gh release create` would create the `v`-tag at the default branch HEAD rather than the pushed
+commit. The intended convention is v-prefixed (`on.push.tags: v*.*.*`). Changed "Create Tag" to use
+`needs.validate.outputs.version` and push that exact tag, so the pushed tag matches the release tag.
+Verified with actionlint + yamllint.
+
+#### [NIT-02] `test` job holds unused write permissions
+
+Fixed: 2026-06-24
+Notes: The `test` job's steps (checkout, setup-node, caches, `npm ci`, tree-sitter parse) never call
+the issues, pull-requests, or actions APIs, yet it granted `issues: write`, `pull-requests: write`,
+and `actions: read` with comments claiming "test tooling" needs them. Reduced to `contents: read`.
+
+#### [NIT-04] `coverage` job holds unused write permissions
+
+Fixed: 2026-06-24
+Notes: The `coverage` job builds `coverage_report.md` but only `cat`s it — it never posts to issues
+or PRs and never reads the Actions API. Removed unused `issues: write`, `pull-requests: write`, and
+`actions: read`; reduced to `contents: read`.
+
+## Invalid
+
+### Pass 1 — 2026-06-24
+
+#### [NIT-07] Re-enabling BASH_BASH_EXEC would fail the lint job
+
+Notes: Initially suspected: this branch removes `BASH_BASH_EXEC` from `DISABLE_LINTERS`, and
+`test/spec/*.sh` are non-executable. But `FILTER_REGEX_EXCLUDE` in `.mega-linter.yml` globally
+excludes `test/spec`, and the only other `.sh` outside excluded paths
+(`scripts/post-generate.sh`) is already executable. So the re-enabled linter has nothing to flag —
+no defect.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
       },
       "devDependencies": {
         "editorconfig-checker": "^6.1.1",
-        "markdownlint-cli": "^0.48.0",
+        "markdownlint-cli": "^0.49.0",
         "nodemon": "^3.0.1",
         "prettier": "^3.6.2",
         "tree-sitter-cli": "^0.26.6"
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -192,13 +192,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/debug": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -484,10 +484,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -514,9 +524,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.38",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.38.tgz",
-      "integrity": "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -541,25 +551,45 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -569,9 +599,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
+      "integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,40 +613,40 @@
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
         "micromark-util-types": "2.0.2",
-        "string-width": "8.1.0"
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
-      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.0.tgz",
+      "integrity": "sha512-vS5tWq5W91Gg33LD4pyAaXPclnz/sRvo6/RGOyDQjQ3eds2DkK6H4szUuE0M9TiRB/u/VBx1gtd9Ktrtx5WlSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "~14.0.3",
+        "commander": "~15.0.0",
         "deep-extend": "~0.6.0",
         "ignore": "~7.0.5",
-        "js-yaml": "~4.1.1",
+        "js-yaml": "~4.2.0",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.1.1",
-        "markdownlint": "~0.40.0",
-        "minimatch": "~10.2.4",
+        "markdown-it": "~14.2.0",
+        "markdownlint": "~0.41.0",
+        "minimatch": "~10.2.5",
         "run-con": "~1.3.2",
-        "smol-toml": "~1.6.0",
-        "tinyglobby": "~0.2.15"
+        "smol-toml": "~1.6.1",
+        "tinyglobby": "~0.2.17"
       },
       "bin": {
         "markdownlint": "markdownlint.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/mdurl": {
@@ -1163,13 +1193,13 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1196,9 +1226,9 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -1275,9 +1305,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1288,9 +1318,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1350,9 +1380,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1376,9 +1406,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1389,14 +1419,14 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -1448,14 +1478,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1483,9 +1513,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1538,9 +1568,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.26.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.6.tgz",
-      "integrity": "sha512-aMC+NcvjGGAE63UNiaZLpcLwMT53tc6ikVLas5Edm+HmiM4NJ9wY05Nrug487gonGKdPz6e48zHsTnVEHAH1HA==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.9.tgz",
+      "integrity": "sha512-7l+U1RmazPVe+yA/JiX80GFOILnL/j24GbawamIzNQC8UlINrcyECbaWGaG1wuq4j/m0DQTx7Uu4r0iW9Ao1BQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "editorconfig-checker": "^6.1.1",
-    "markdownlint-cli": "^0.48.0",
+    "markdownlint-cli": "^0.49.0",
     "nodemon": "^3.0.1",
     "prettier": "^3.6.2",
     "tree-sitter-cli": "^0.26.6"


### PR DESCRIPTION
This pull request primarily updates dependencies and GitHub Actions workflows to use newer versions, and removes an unused pre-commit hook. These changes help keep the project up-to-date and maintain security and compatibility.

**GitHub Actions Workflow Updates:**

* Updated all uses of `ivuorinen/actions` in workflow files (`codeql-analysis`, `pr-lint`, `stale`, `sync-labels`) to version `8395dad6b7d5d7d2e1d016cac1eede33ab404a3c` (`v2026.06.18`) for consistency and to benefit from the latest improvements and fixes. (.github/workflows/codeql.yml [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L31-R31) .github/workflows/pr-lint.yml [[2]](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dL30-R30) .github/workflows/stale.yml [[3]](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L26-R26) .github/workflows/sync-labels.yml [[4]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L40-R40) .github/workflows/test.yml [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L192-R192)
* Updated `softprops/action-gh-release` in `release.yml` to version `3.0.1` for the latest release enhancements. (.github/workflows/release.yml [.github/workflows/release.ymlL251-R251](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L251-R251))
* Updated the comment for `actions/github-script` in `release.yml` to reflect the version as `v9.0.0`. (.github/workflows/release.yml [.github/workflows/release.ymlL73-R73](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L73-R73))

**Development Dependency Updates:**

* Bumped `markdownlint-cli` in `package.json` from `^0.48.0` to `^0.49.0` to use the latest linter features and fixes. (package.json [package.jsonL55-R55](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L55-R55))

**Pre-commit Hook Cleanup:**

* Removed the `renovate-config-validator` pre-commit hook from `.pre-commit-config.yaml`, likely because it's no longer needed or relevant. (.pre-commit-config.yaml [.pre-commit-config.yamlL47-L51](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L47-L51))